### PR TITLE
Improvements to vulnerability update

### DIFF
--- a/src/mh/vulnerability/_includes/04-elderly-support-no-password.njk
+++ b/src/mh/vulnerability/_includes/04-elderly-support-no-password.njk
@@ -8,13 +8,13 @@
   </ns-inputter>
   <ns-inputter validation="[]" heading="Carers and supporting persons" helper="" name="carers">
     <input type="checkbox" id="carer" value="carer" class="np-toggler not-psr">
-    <label for="carer">I have a carer or, I am a carer</label>
+    <label for="carer">You have or you are a carer or personal assistant</label>
     {% include "./ns-highlighter-carer.njk" %}
     <input type="checkbox" id="presence" value="presence">
-    <label for="presence">Additional presence preferred</label>
+    <label for="presence">You prefer to have a friend or family member present for home visits</label>
     <input type="checkbox" id="nominee" value="nominee" class="not-psr">
-    <label for="nominee">Nominated person on the account</label>
+    <label for="nominee">You have nominated someone to speak on your behalf</label>
     <input type="checkbox" id="attorney" value="attorney">
-    <label for="attorney">Power of attorney</label>
+    <label for="attorney">You have or you are power of attorney</label>
   </ns-inputter>
 </ns-form>

--- a/src/mh/vulnerability/_includes/05-communication.njk
+++ b/src/mh/vulnerability/_includes/05-communication.njk
@@ -1,4 +1,4 @@
-<h3 slot="heading">Communication and language</h3>
+<h3 slot="heading">Communication and language barrier</h3>
 <ns-form>
   <ns-inputter validation="[]" heading="Communication" helper="" name="communication">
     <input type="checkbox" id="speech" name="speech" value="speech">
@@ -44,7 +44,7 @@
       <option>Textphone</option>
     </select>
   </ns-inputter>
-  <ns-inputter validation="[]" heading="Language" helper="" name="language">
+  <ns-inputter validation="[]" heading="Language (non English speaking)" helper="" name="language">
     <input type="checkbox" id="arabic" value="arabic">
     <label for="arabic">Arabic</label>
     <input type="checkbox" id="bengali" value="bengali">

--- a/src/mh/vulnerability/_includes/06-personal-circumstance.njk
+++ b/src/mh/vulnerability/_includes/06-personal-circumstance.njk
@@ -1,4 +1,4 @@
-<h3 slot="heading">Personal circumstances</h3>
+<h3 slot="heading">Personal and temporary circumstances</h3>
 <ns-form>
   <ns-inputter validation="[]" heading="Personal circumstances" helper="This can include any temporary changes could include bereavement, that could make it hard coping with everyday life situations." name="personal">
     <input type="checkbox" id="bereavement" value="bereavement" class="not-psr">

--- a/src/mh/vulnerability/_includes/07-personal-password.njk
+++ b/src/mh/vulnerability/_includes/07-personal-password.njk
@@ -1,11 +1,8 @@
 <h3 slot="heading">Personal password for home visits</h3>
 <ns-form>
   <ns-fieldset legend="Sign up to our password scheme">
-    <ns-inputter validation="[]" helper="What is a password scheme? this is an optional choice" name="password">
-      <div slot="tip-details">
-        <p>You can ask our engineers and meter readers to use a personal password when they visit your home, so you know they're really from British Gas.</p>
-      </div>
-      <label slot="label">Set a password</label>
+    <ns-inputter validation="[]" helper="You can ask our engineers and meter readers to use a personal password when they visit your home, so you know they're really from British Gas." name="password">
+      <label slot="label">Set a personal password</label>
       <input type="text">
     </ns-inputter>
   </ns-fieldset>

--- a/src/mh/vulnerability/_includes/extra-help.njk
+++ b/src/mh/vulnerability/_includes/extra-help.njk
@@ -1,7 +1,7 @@
 <ns-form>
   <ns-inputter validation="[&quot;isRequired&quot;]" heading="Don't require extra help?" name="name-b">
     <input type="checkbox" id="answer-2a" name="name-b" value="a">
-    <label for="answer-2a">No, there's no one vulnerable living at your property</label>
+    <label for="answer-2a">There's no household circumstances you want to share</label>
   </ns-inputter>
   <ns-cta>Continue to next step</ns-cta>
 </ns-form>

--- a/src/mh/vulnerability/update.njk
+++ b/src/mh/vulnerability/update.njk
@@ -1,6 +1,6 @@
 ---
 title: Vulnerability 2020-07-30
-branch: 0dad7b31af2c6cf1db9613921ab7fb40378fd5fb
+branch: 010c8bd31d2ed1d0b9f9f68e8ee36a744adbd427
 eleventyNavigation:
   key: Vulnerability
   parent: mh

--- a/src/mh/vulnerability/update.njk
+++ b/src/mh/vulnerability/update.njk
@@ -1,73 +1,20 @@
 ---
-title: Vulnerability 2020-07-28
+title: Vulnerability 2020-07-30
 branch: 0dad7b31af2c6cf1db9613921ab7fb40378fd5fb
 eleventyNavigation:
   key: Vulnerability
   parent: mh
-  title: Vulnerability 2020-07-28
+  title: Vulnerability 2020-07-30
   excerpt: An update to the 2020-07-21 version of the personal circumstances prototype.
 ---
 
-<ns-landmark type="lakeside">
+<ns-landmark type="hillside">
   <h1 slot="heading">
-    <span class="h5">Your account.</span>
-    <span class="h1">Account details</span>
+    <span class="h5">Here to solve.</span>
+    <span class="h1">Household circumstances</span>
   </h1>
-  <p slot="paragraph">Account management, personal information, password and marketing settings.</p>
+  <p slot="paragraph">We're here to solve and provide extra help where we can.</p>
 </ns-landmark>
-
-<ns-panel>
-  <div class="splash">
-    <dl class="dl-row">
-      <div>
-        <dt>Name</dt>
-        <dd>Scottie Robertson</dd>
-        <dd>
-          <a href="#!">Update name</a>
-        </dd>
-      </div>
-      <div>
-        <dt>Correspondence address</dt>
-        <dd>11 Coombe Pine<br>Bracknell<br>RG12 0TJ</dd>
-        <dd>
-          <a href="#!">Change address</a>
-        </dd>
-      </div>
-      <div>
-        <dt>Contact details</dt>
-        <dd>
-          <p>07530 099887</p>
-          <p>01483 938842</p>
-        </dd>
-        <dd>
-          <a href="#!">Update contact details</a>
-        </dd>
-      </div>
-      <div>
-        <dt>Login details</dt>
-        <dd>
-          <p>scott@email.com</p>
-          <p>**********</p>
-        </dd>
-        <dd>
-          <a href="#!">Edit login details</a>
-        </dd>
-      </div>
-      <div>
-        <dt>Marketing</dt>
-        <dd>
-          <ul class="ul-ticked">
-            <li>Email</li>
-            <li>SMS</li>
-          </ul>
-        </dd>
-        <dd>
-          <a href="#!">Change marketing preferences</a>
-        </dd>
-      </div>
-    </dl>
-  </div>
-</ns-panel>
 
 <ns-panel>
   <div class="splash">


### PR DESCRIPTION
- Change Language expand to include barrier
- In the language section add (non-English speaking to the heading)
- Remove the tip expander from password and show detail
- Personal circumstances expander - change to Personal or temporary circumstances
- Update naming of carer and support options to (on screen shot)
- Remove account details landmark and other account options and use a landmark for a standalone page (Account details won't be ready to house this section)
- Update the no action copy to be less about vulnerability